### PR TITLE
ユーザー検索機能に招待受信設定のフィルタを追加し、プロフィール設定にパスワードリセット機能を実装

### DIFF
--- a/backend/src/user/handlers.ts
+++ b/backend/src/user/handlers.ts
@@ -77,7 +77,7 @@ export const deleteUserHandler = async (
 
 // メールアドレスからユーザーを検索
 export const searchUserHandler = async (email: string) => {
-  // 認可処理：なし => 誰でも実行可能
+  // Firestoreからメールアドレスでユーザーを検索
   const users = await db().users.lis(
     [
       { field: "email", op: "==", value: email },

--- a/backend/src/user/handlers.ts
+++ b/backend/src/user/handlers.ts
@@ -79,7 +79,10 @@ export const deleteUserHandler = async (
 export const searchUserHandler = async (email: string) => {
   // 認可処理：なし => 誰でも実行可能
   const users = await db().users.lis(
-    [{ field: "email", op: "==", value: email }],
+    [
+      { field: "email", op: "==", value: email },
+      { field: "profile.acceptsInvite", op: "==", value: true },
+    ],
     10,
   );
 

--- a/frontend/src/app/setting/page/main.tsx
+++ b/frontend/src/app/setting/page/main.tsx
@@ -52,12 +52,7 @@ const MainPage = () => {
   };
 
   const handleReset = async () => {
-    try {
-      await resetPassword(currentUserData.email);
-      raiseError("パスワードリセットメールを送信しました", "success");
-    } catch (error) {
-      raiseError("パスワードリセットメールの送信に失敗しました", "error");
-    }
+    await resetPassword(currentUserData.email);
   };
 
   return (

--- a/frontend/src/app/setting/page/main.tsx
+++ b/frontend/src/app/setting/page/main.tsx
@@ -1,4 +1,4 @@
-import { useAuthContext } from "@f/authContext";
+import { resetPassword, useAuthContext } from "@f/authContext";
 import { raiseError } from "@f/errorHandler";
 import { hc } from "@f/lib/api/api";
 import InputGroupUI from "@f/lib/style/imputGroupUI";
@@ -51,6 +51,15 @@ const MainPage = () => {
     }
   };
 
+  const handleReset = async () => {
+    try {
+      await resetPassword(currentUserData.email);
+      raiseError("パスワードリセットメールを送信しました", "success");
+    } catch (error) {
+      raiseError("パスワードリセットメールの送信に失敗しました", "error");
+    }
+  };
+
   return (
     <>
       <div className="card mb-3">
@@ -86,7 +95,7 @@ const MainPage = () => {
         <div className="card-body">
           <h2 className="card-title mb-3">セキュリティ設定</h2>
           <p>
-            グループからの招待を受け取るかどうかを設定します。招待を拒否すると、グループからの新しい招待が届かなくなります。
+            あなたのアカウントが他のユーザに表示されるかどうかを設定します。招待を拒否すると、グループからの新しい招待が届かなくなります。
             <br />
             既に受け取っている招待には影響しません。
           </p>
@@ -103,8 +112,8 @@ const MainPage = () => {
                 })
               }
             >
-              <option value="accept">招待を受け取る</option>
-              <option value="deny">招待を受け取らない</option>
+              <option value="accept">プロフィールを表示する</option>
+              <option value="deny">プロフィールを表示しない</option>
             </FormSelect>
           </div>
         </div>
@@ -131,6 +140,18 @@ const MainPage = () => {
             }}
           >
             アカウントを削除する
+          </Button>
+        </div>
+      </div>
+
+      <div className="card mb-3">
+        <div className="card-body">
+          <h2 className="card-title mb-3">パスワードリセット</h2>
+          <p>
+            パスワードを忘れた場合やセキュリティのためにパスワードを変更したい場合は、以下のボタンをクリックしてパスワードリセットメールを送信してください。メールに記載された手順に従って新しいパスワードを設定できます。
+          </p>
+          <Button variant="warning" onClick={handleReset}>
+            パスワードリセットメールを送信
           </Button>
         </div>
       </div>

--- a/frontend/src/authContext.tsx
+++ b/frontend/src/authContext.tsx
@@ -206,28 +206,28 @@ export const login = async (email: string, password: string) => {
   try {
     await signInWithEmailAndPassword(auth, email, password);
   } catch (error) {
-    raiseError("Login failed:", "error", String(error));
+    raiseError("ログインに失敗しました", "error", String(error));
   }
 };
 export const logout = async () => {
   try {
     await signOut(auth);
   } catch (error) {
-    raiseError("Logout failed:", "error", String(error));
+    raiseError("ログアウトに失敗しました", "error", String(error));
   }
 };
 export const register = async (email: string, password: string) => {
   try {
     await createUserWithEmailAndPassword(auth, email, password);
   } catch (error) {
-    raiseError("Registration failed:", "error", String(error));
+    raiseError("登録に失敗しました", "error", String(error));
   }
 };
 export const resetPassword = async (email: string) => {
   try {
     await sendPasswordResetEmail(auth, email);
   } catch (error) {
-    raiseError("Password reset failed:", "error", String(error));
+    raiseError("パスワードリセットに失敗しました", "error", String(error));
   }
 };
 export const updateEmail = async (email: string) => {
@@ -235,7 +235,7 @@ export const updateEmail = async (email: string) => {
     try {
       await verifyBeforeUpdateEmail(auth.currentUser, email);
     } catch (error) {
-      raiseError("Email update failed:", "error", String(error));
+      raiseError("メールアドレスの更新に失敗しました", "error", String(error));
     }
   }
 };
@@ -244,7 +244,7 @@ export const sendVerificationEmail = async () => {
     try {
       await sendEmailVerification(auth.currentUser);
     } catch (error) {
-      raiseError("Verification email sending failed:", "error", String(error));
+      raiseError("確認メールの送信に失敗しました", "error", String(error));
     }
   }
 };

--- a/frontend/src/authContext.tsx
+++ b/frontend/src/authContext.tsx
@@ -15,6 +15,7 @@ import {
   sendPasswordResetEmail,
   signInWithEmailAndPassword,
   signOut,
+  verifyBeforeUpdateEmail,
   type User,
 } from "firebase/auth";
 import { auth } from "./firebase";
@@ -227,6 +228,15 @@ export const resetPassword = async (email: string) => {
     await sendPasswordResetEmail(auth, email);
   } catch (error) {
     raiseError("Password reset failed:", "error", String(error));
+  }
+};
+export const updateEmail = async (email: string) => {
+  if (auth.currentUser) {
+    try {
+      await verifyBeforeUpdateEmail(auth.currentUser, email);
+    } catch (error) {
+      raiseError("Email update failed:", "error", String(error));
+    }
   }
 };
 export const sendVerificationEmail = async () => {


### PR DESCRIPTION
This pull request introduces several improvements to both the backend and frontend related to user privacy and account management. The main changes include updating the user search logic to respect privacy settings, adding a password reset feature to the settings page, and enhancing the descriptions and options for profile visibility. Additionally, support for email update verification has been added.

**User privacy and search logic:**
- The backend user search (`searchUserHandler` in `handlers.ts`) now only returns users who have set their profile to accept invites, improving privacy by hiding users who opted out.

**Account management features:**
- A password reset feature has been added to the settings page (`main.tsx`). Users can now request a password reset email directly from the UI. [[1]](diffhunk://#diff-9da2ff5458e0aaf95fbab0f4b958caab06cde67d3e59c373a8271932ec9996a5L1-R1) [[2]](diffhunk://#diff-9da2ff5458e0aaf95fbab0f4b958caab06cde67d3e59c373a8271932ec9996a5R54-R62) [[3]](diffhunk://#diff-9da2ff5458e0aaf95fbab0f4b958caab06cde67d3e59c373a8271932ec9996a5R146-R157)
- The frontend authentication context now includes an `updateEmail` function, which sends a verification email when users attempt to change their email address. [[1]](diffhunk://#diff-57630d8a1786a4c891daf1e9ed4425871a7e13756bd593bd728c16d175662aecR18) [[2]](diffhunk://#diff-57630d8a1786a4c891daf1e9ed4425871a7e13756bd593bd728c16d175662aecR233-R241)

**UI and messaging improvements:**
- The security settings section's description and options have been updated to clarify that they control profile visibility, not just invite acceptance. Option labels now reflect profile visibility rather than invitation acceptance. [[1]](diffhunk://#diff-9da2ff5458e0aaf95fbab0f4b958caab06cde67d3e59c373a8271932ec9996a5L89-R98) [[2]](diffhunk://#diff-9da2ff5458e0aaf95fbab0f4b958caab06cde67d3e59c373a8271932ec9996a5L106-R116)