### PR TITLE
Fix scout detail access and authentication cache handling

### DIFF
--- a/backend/src/lib/firestore/schemas.ts
+++ b/backend/src/lib/firestore/schemas.ts
@@ -279,7 +279,7 @@ export type UserRecordSchemaType = z.infer<typeof UserRecordSchema>;
 const GroupUserSettingsSchema = z.object({
   allowSendScout: z.boolean().default(false),
   allowShare: z.boolean().default(true),
-  name: z.string().max(100),
+  name: z.string().max(100).default("団名"),
 });
 
 const GroupAdminTagsSchema = z.object({

--- a/backend/src/lib/userData.ts
+++ b/backend/src/lib/userData.ts
@@ -42,6 +42,7 @@ export const loadUserData = async (c: Context, next: () => Promise<void>) => {
   if (!userData) {
     return c.json("USER_DATA_NOT_FOUND", 404);
   }
+
   const groups = userData.auth.memberships.map((m) => {
     const { id, role } = IdWithGroupRoleParser(m);
     return { id, role };

--- a/frontend/src/app/scoutDetail/scoutDetail.tsx
+++ b/frontend/src/app/scoutDetail/scoutDetail.tsx
@@ -12,7 +12,7 @@ const ScoutDetail = (): React.ReactElement => {
   const id = useLocation().pathname.split("/")[3]; // /app/scouts/:id newになることはない。
   const mode = useLocation().pathname.split("/")[4];
 
-  const { currentGroup, user } = useAuthContext();
+  const { user } = useAuthContext();
   const scoutQuery = useQuery({
     queryKey: ["scout", id],
     queryFn: (): Promise<ScoutData> =>
@@ -34,9 +34,13 @@ const ScoutDetail = (): React.ReactElement => {
 
   if (scoutQuery.data) {
     const scoutData = scoutQuery.data;
-    const isEditable = currentGroup
-      ? currentGroup.role == "ADMIN" || currentGroup.role == "EDIT"
-      : user.auth.shares.find((s) => s.id == id)?.role == "EDIT";
+    const groupRole = user.auth.memberships.find(
+      (membership) => membership.id === scoutData.belongGroupId,
+    )?.role;
+    const isEditable =
+      groupRole === "ADMIN" ||
+      groupRole === "EDIT" ||
+      user.auth.shares.find((share) => share.id === id)?.role === "EDIT";
 
     if (mode === "view") {
       // ビューモードの処理

--- a/frontend/src/app/scoutDetail/view/events.tsx
+++ b/frontend/src/app/scoutDetail/view/events.tsx
@@ -65,7 +65,7 @@ const Events = ({ events }: { events: Event[] }) => {
           eventList.map((event, index) => (
             <ShowData
               key={"event-" + index}
-              label={event.startDate}
+              label={event.name}
               value={`${event.startDate}～${event.endDate}`}
             />
           ))

--- a/frontend/src/authContext.tsx
+++ b/frontend/src/authContext.tsx
@@ -68,7 +68,7 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({
       if (!fbUser) {
         setToken(null);
         setHcClient();
-        queryClient.removeQueries({ queryKey: ["current-user"] });
+        queryClient.clear();
         setIsAuthLoaded(true);
         return;
       }


### PR DESCRIPTION
## What changed

- clear all React Query caches when the user logs out
- determine scout editability from the scout's owning group instead of the currently selected group
- preserve EDIT share access when determining editability
- add a default group name for legacy or incomplete group settings
- display event names as event labels in scout details

## Why

User-scoped query data could remain in memory after logout and be reused by another account in the same browser. Scout edit controls could also be shown or hidden using an unrelated currently selected group. The additional small fixes complete the local work that had not yet been pushed.

## Impact

Logging out now discards cached server data, so the next login fetches fresh data. Scout edit controls now match the target scout's owning-group role or an explicit EDIT share.

## Validation

- `npm run build` in `frontend/` (TypeScript, ESLint, and Vite production build)
- `git diff --check`